### PR TITLE
Add 16bit ddr3 mt41 k128 m16 support

### DIFF
--- a/drivers/extram/ddram.c
+++ b/drivers/extram/ddram.c
@@ -73,14 +73,26 @@
 #ifdef CONFIG_HAVE_MPDDRC_DDR3
 
 #ifdef CONFIG_HAVE_DDR3_MT41K128M16
-static void _init_mt41k128m16(struct _mpddrc_desc* desc)
+static void _init_mt41k128m16(struct _mpddrc_desc* desc, uint8_t bus_width)
 {
 	uint32_t mck = pmc_get_master_clock() / 1000000;
 
 	desc->type = MPDDRC_TYPE_DDR3;
 
+#ifdef MPDDRC_MD_DBW_DBW_32_BITS
+	if (bus_width == 16) {
+#ifdef MPDDRC_MD_DBW_DBW_16_BITS
+		desc->mode = MPDDRC_MD_MD_DDR3_SDRAM
+		           | MPDDRC_MD_DBW_DBW_16_BITS;
+#endif
+	} else {
+		desc->mode = MPDDRC_MD_MD_DDR3_SDRAM
+		           | MPDDRC_MD_DBW_DBW_32_BITS;
+	}
+#else
 	desc->mode = MPDDRC_MD_MD_DDR3_SDRAM
-	           | MPDDRC_MD_DBW_DBW_32_BITS;
+	           | MPDDRC_MD_DBW_DBW_16_BITS;
+#endif
 
 #ifdef CONFIG_HAVE_MPDDRC_DATA_PATH
 	desc->data_path = MPDDRC_RD_DATA_PATH_SHIFT_SAMPLING_SHIFT_TWO_CYCLES;
@@ -718,7 +730,10 @@ void ddram_init_descriptor(struct _mpddrc_desc* desc,
 #ifdef CONFIG_HAVE_MPDDRC_DDR3
   #ifdef CONFIG_HAVE_DDR3_MT41K128M16
 	case MT41K128M16:
-		_init_mt41k128m16(desc);
+		_init_mt41k128m16(desc, 32);
+		break;
+	case MT41K128M16_16:
+		_init_mt41k128m16(desc, 16);
 		break;
   #endif
 #endif

--- a/drivers/extram/ddram.h
+++ b/drivers/extram/ddram.h
@@ -74,6 +74,7 @@ enum _ddram_devices {
 #endif
 #ifdef CONFIG_HAVE_MPDDRC_DDR3
   #ifdef CONFIG_HAVE_DDR3_MT41K128M16
+	MT41K128M16_16,/* DDR3 1*256MB */
 	MT41K128M16,   /* DDR3 2*256MB */
   #endif
 #endif

--- a/flash_loaders/applets/extram/extram_flash_loader.c
+++ b/flash_loaders/applets/extram/extram_flash_loader.c
@@ -167,6 +167,10 @@ uint32_t FlashInit(void *base_of_flash,
 		trace_warning_wp("Preset 4 (2 x MT41K128M16)\r\n");
 		device = MT41K128M16;
 		break;
+	case 12:
+		trace_warning_wp("Preset 12 (1 x MT41K128M16)\r\n");
+		device = MT41K128M16_16;
+		break;
 #endif
 #ifdef CONFIG_HAVE_LPDDR3_EDF8164A3MA
 	case 5:

--- a/samba_applets/extram/main.c
+++ b/samba_applets/extram/main.c
@@ -96,6 +96,10 @@ static bool init_extram_from_preset(uint32_t preset)
 		trace_warning_wp("Preset 4 (2 x MT41K128M16)\r\n");
 		device = MT41K128M16;
 		break;
+	case 12:
+		trace_warning_wp("Preset 12 (1 x MT41K128M16)\r\n");
+		device = MT41K128M16_16;
+		break;
 #endif
 #ifdef CONFIG_HAVE_LPDDR3_EDF8164A3MA
 	case 5:


### PR DESCRIPTION
`extram` doesn't work on the router card because it was missing a preset for our memory configuration.  The Xplained board uses two DDR3 chips for a 32-bit memory bus.  Our board uses just a single DDR3 chip for a 16-bit memory bus.  The series adds support for the latter.

This series will also be merged [upstream](https://github.com/atmelcorp/atmel-software-package/pull/70) for the next release.  But until then, we can carry it in our `xaptum` branch here.